### PR TITLE
fix java11 compile fail, upgrade lombok

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 
     <properties>
         <testcontainers.version>1.15.3</testcontainers.version>
-        <lombok.version>1.16.16</lombok.version>
+        <lombok.version>1.18.22</lombok.version>
         <slf4j.version>1.7.21</slf4j.version>
         <aerospike.version>4.4.2</aerospike.version>
         <dropwizard.guicey.version>4.2.1</dropwizard.guicey.version>


### PR DESCRIPTION
error info:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project junit-testcontainer-commons: Fatal error compiling: java.lang.ExceptionI
nInitializerError: com.sun.tools.javac.code.TypeTags -> [Help 1]
```