### PR TITLE
upgrade dns-cache-manipulator, support java11

### DIFF
--- a/junit-testcontainer-hbase-1.x/pom.xml
+++ b/junit-testcontainer-hbase-1.x/pom.xml
@@ -16,7 +16,7 @@
         <hbase.version>1.3.2</hbase.version>
         <junit.jupiter.version>5.6.0</junit.jupiter.version>
         <mockito.version>2.22.0</mockito.version>
-        <dns.cache.manipulator.version>1.5.0</dns.cache.manipulator.version>
+        <dns.cache.manipulator.version>1.6.3</dns.cache.manipulator.version>
         <awaitility.version>4.1.0</awaitility.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 
     <properties>
         <testcontainers.version>1.15.3</testcontainers.version>
-        <lombok.version>1.16.16</lombok.version>
+        <lombok.version>1.18.22</lombok.version>
         <slf4j.version>1.7.21</slf4j.version>
         <aerospike.version>4.4.2</aerospike.version>
         <dropwizard.guicey.version>4.2.1</dropwizard.guicey.version>


### PR DESCRIPTION
more info see release notes:
https://github.com/alibaba/java-dns-cache-manipulator/releases
