### PR TITLE
Upgraded testcontainers version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Embedded testcontainers library to support JUnit tests for stateful services.
 ### Usage
 Include commons dependency and required datastore testcontainer dependency in your pom
 
-### Latest version : 1.0.6
+### Latest version : 1.0.9
 #### commons maven dependency
 ```xml
  <groupId>io.appform.testcontainer</groupId>

--- a/junit-testcontainer-aerospike/pom.xml
+++ b/junit-testcontainer-aerospike/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
     </parent>
 
     <artifactId>junit-testcontainer-aerospike</artifactId>

--- a/junit-testcontainer-azure-blob/pom.xml
+++ b/junit-testcontainer-azure-blob/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>junit-testcontainer</artifactId>
         <groupId>io.appform.testcontainer</groupId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/junit-testcontainer-commons/pom.xml
+++ b/junit-testcontainer-commons/pom.xml
@@ -25,6 +25,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>ru.vyarus</groupId>
             <artifactId>dropwizard-guicey</artifactId>
         </dependency>

--- a/junit-testcontainer-commons/pom.xml
+++ b/junit-testcontainer-commons/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
     </parent>
 
     <artifactId>junit-testcontainer-commons</artifactId>
@@ -22,11 +22,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java-core</artifactId>
         </dependency>
 
         <dependency>

--- a/junit-testcontainer-demo/pom.xml
+++ b/junit-testcontainer-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
     </parent>
 
     <artifactId>junit-testcontainer-demo</artifactId>

--- a/junit-testcontainer-elasticsearch/pom.xml
+++ b/junit-testcontainer-elasticsearch/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
     </parent>
 
     <artifactId>junit-testcontainer-elasticsearch</artifactId>

--- a/junit-testcontainer-hbase-1.x/pom.xml
+++ b/junit-testcontainer-hbase-1.x/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
     </parent>
 
     <artifactId>junit-testcontainer-hbase-1.x</artifactId>

--- a/junit-testcontainer-hbase-2.x/pom.xml
+++ b/junit-testcontainer-hbase-2.x/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
     </parent>
 
     <artifactId>junit-testcontainer-hbase-2.x</artifactId>

--- a/junit-testcontainer-mariadb/pom.xml
+++ b/junit-testcontainer-mariadb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
     </parent>
 
     <artifactId>junit-testcontainer-mariadb</artifactId>

--- a/junit-testcontainer-rabbitmq/pom.xml
+++ b/junit-testcontainer-rabbitmq/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
     </parent>
 
     <artifactId>junit-testcontainer-rabbitmq</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
         <slf4j.version>1.7.21</slf4j.version>
         <aerospike.version>4.4.2</aerospike.version>
         <dropwizard.guicey.version>4.2.1</dropwizard.guicey.version>
+        <docker.java.version>3.2.13</docker.java.version>
     </properties>
 
     <dependencyManagement>
@@ -123,6 +124,14 @@
                 <groupId>com.aerospike</groupId>
                 <artifactId>aerospike-client</artifactId>
                 <version>${aerospike.version}</version>
+            </dependency>
+
+            <!-- Docker Java Client -->
+
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-core</artifactId>
+                <version>${docker.java.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.testcontainer</groupId>
     <artifactId>junit-testcontainer</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
     <packaging>pom</packaging>
     <name>Embedded Testcontainers</name>
     <description>Embedded testcontainers for data stores</description>
@@ -82,12 +82,11 @@
 
 
     <properties>
-        <testcontainers.version>1.15.3</testcontainers.version>
+        <testcontainers.version>1.17.2</testcontainers.version>
         <lombok.version>1.18.22</lombok.version>
         <slf4j.version>1.7.21</slf4j.version>
         <aerospike.version>4.4.2</aerospike.version>
         <dropwizard.guicey.version>4.2.1</dropwizard.guicey.version>
-        <docker.java.version>3.2.8</docker.java.version>
     </properties>
 
     <dependencyManagement>
@@ -124,14 +123,6 @@
                 <groupId>com.aerospike</groupId>
                 <artifactId>aerospike-client</artifactId>
                 <version>${aerospike.version}</version>
-            </dependency>
-
-            <!-- Docker Java Client -->
-
-            <dependency>
-                <groupId>com.github.docker-java</groupId>
-                <artifactId>docker-java-core</artifactId>
-                <version>${docker.java.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
The current version has an incompatible jna dependency, and fails on an M1 mac
https://github.com/testcontainers/testcontainers-java/issues/3610

The PR upgrades the version of testcontainers which has the fix.
Also upgraded `docker.java.version` to right compatible version
