### PR TITLE
RabbitMQ management port support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Embedded testcontainers library to support JUnit tests for stateful services.
 ### Usage
 Include commons dependency and required datastore testcontainer dependency in your pom
 
-### Latest version : 1.0.12
+### Latest version : 1.0.14
 #### commons maven dependency
 ```xml
  <groupId>io.appform.testcontainer</groupId>

--- a/junit-testcontainer-aerospike/pom.xml
+++ b/junit-testcontainer-aerospike/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.13</version>
+        <version>1.0.14</version>
     </parent>
 
     <artifactId>junit-testcontainer-aerospike</artifactId>

--- a/junit-testcontainer-azure-blob/pom.xml
+++ b/junit-testcontainer-azure-blob/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>junit-testcontainer</artifactId>
         <groupId>io.appform.testcontainer</groupId>
-        <version>1.0.13</version>
+        <version>1.0.14</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/junit-testcontainer-commons/pom.xml
+++ b/junit-testcontainer-commons/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.13</version>
+        <version>1.0.14</version>
     </parent>
 
     <artifactId>junit-testcontainer-commons</artifactId>

--- a/junit-testcontainer-demo/pom.xml
+++ b/junit-testcontainer-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.13</version>
+        <version>1.0.14</version>
     </parent>
 
     <artifactId>junit-testcontainer-demo</artifactId>

--- a/junit-testcontainer-elasticsearch/pom.xml
+++ b/junit-testcontainer-elasticsearch/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.13</version>
+        <version>1.0.14</version>
     </parent>
 
     <artifactId>junit-testcontainer-elasticsearch</artifactId>

--- a/junit-testcontainer-hbase-1.x/pom.xml
+++ b/junit-testcontainer-hbase-1.x/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.13</version>
+        <version>1.0.14</version>
     </parent>
 
     <artifactId>junit-testcontainer-hbase-1.x</artifactId>

--- a/junit-testcontainer-hbase-2.x/pom.xml
+++ b/junit-testcontainer-hbase-2.x/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.13</version>
+        <version>1.0.14</version>
     </parent>
 
     <artifactId>junit-testcontainer-hbase-2.x</artifactId>

--- a/junit-testcontainer-mariadb/pom.xml
+++ b/junit-testcontainer-mariadb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.13</version>
+        <version>1.0.14</version>
     </parent>
 
     <artifactId>junit-testcontainer-mariadb</artifactId>

--- a/junit-testcontainer-rabbitmq/pom.xml
+++ b/junit-testcontainer-rabbitmq/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.13</version>
+        <version>1.0.14</version>
     </parent>
 
     <artifactId>junit-testcontainer-rabbitmq</artifactId>

--- a/junit-testcontainer-rabbitmq/src/main/java/io/appform/testcontainers/rabbitmq/config/RabbitMQContainerConfiguration.java
+++ b/junit-testcontainer-rabbitmq/src/main/java/io/appform/testcontainers/rabbitmq/config/RabbitMQContainerConfiguration.java
@@ -32,11 +32,12 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 public class RabbitMQContainerConfiguration extends CommonContainerConfiguration {
     public static final String BEAN_NAME_EMBEDDED_RABBITMQ = "embeddedRabbitMq";
-    private String dockerImage = "rabbitmq:3-alpine";
+    private String dockerImage = "rabbitmq:3.8.34-management";
 
     private String user = "rabbitmq";
     private String password = "rabbitmq";
     private String host = "localhost";
     private String vhost = "/";
     private int port = 5672;
+    private int managementPort = 15672;
 }

--- a/junit-testcontainer-rabbitmq/src/main/java/io/appform/testcontainers/rabbitmq/container/RabbitMQContainer.java
+++ b/junit-testcontainer-rabbitmq/src/main/java/io/appform/testcontainers/rabbitmq/container/RabbitMQContainer.java
@@ -24,11 +24,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         this.withEnv("RABBITMQ_DEFAULT_VHOST", rabbitMQContainerConfiguration.getVhost())
             .withEnv("RABBITMQ_DEFAULT_USER", rabbitMQContainerConfiguration.getUser())
             .withEnv("RABBITMQ_DEFAULT_PASS", rabbitMQContainerConfiguration.getPassword())
-            .withExposedPorts(rabbitMQContainerConfiguration.getPort())
+            .withExposedPorts(rabbitMQContainerConfiguration.getPort(), rabbitMQContainerConfiguration.getManagementPort())
             .withLogConsumer(ContainerUtils.containerLogsConsumer(log))
             .waitingFor(new RabbitMQStatusCheck(rabbitMQContainerConfiguration))
             .withStartupTimeout(rabbitMQContainerConfiguration.getTimeoutDuration());
-
         this.rabbitMQContainerConfiguration = rabbitMQContainerConfiguration;
     }
 

--- a/junit-testcontainer-zookeeper/pom.xml
+++ b/junit-testcontainer-zookeeper/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.13</version>
+        <version>1.0.14</version>
     </parent>
 
     <artifactId>junit-testcontainer-zookeeper</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.testcontainer</groupId>
     <artifactId>junit-testcontainer</artifactId>
-    <version>1.0.13</version>
+    <version>1.0.14</version>
     <packaging>pom</packaging>
     <name>Embedded Testcontainers</name>
     <description>Embedded testcontainers for data stores</description>


### PR DESCRIPTION
This is required for certain scenarios where management apis are used for health checks. 