### PR TITLE
Delayed Startup check Strategy Added for common use

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Embedded testcontainers library to support JUnit tests for stateful services.
 ### Usage
 Include commons dependency and required datastore testcontainer dependency in your pom
 
-### Latest version : 1.0.14
+### Latest version : 1.0.15
 #### commons maven dependency
 ```xml
  <groupId>io.appform.testcontainer</groupId>

--- a/junit-testcontainer-aerospike/pom.xml
+++ b/junit-testcontainer-aerospike/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.14</version>
+        <version>1.0.15</version>
     </parent>
 
     <artifactId>junit-testcontainer-aerospike</artifactId>

--- a/junit-testcontainer-azure-blob/pom.xml
+++ b/junit-testcontainer-azure-blob/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>junit-testcontainer</artifactId>
         <groupId>io.appform.testcontainer</groupId>
-        <version>1.0.14</version>
+        <version>1.0.15</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/junit-testcontainer-commons/pom.xml
+++ b/junit-testcontainer-commons/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.14</version>
+        <version>1.0.15</version>
     </parent>
 
     <artifactId>junit-testcontainer-commons</artifactId>

--- a/junit-testcontainer-commons/pom.xml
+++ b/junit-testcontainer-commons/pom.xml
@@ -38,6 +38,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+
+         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+             <version>4.0.2</version>
+        </dependency>
     </dependencies>
 
 

--- a/junit-testcontainer-commons/src/main/java/io/appform/testcontainers/commons/IsRunningStartupCheckStrategyWithDelay.java
+++ b/junit-testcontainer-commons/src/main/java/io/appform/testcontainers/commons/IsRunningStartupCheckStrategyWithDelay.java
@@ -13,8 +13,8 @@ import java.util.concurrent.TimeUnit;
  * Sometimes the test container startup checks fails due to container not up or busy in acquiring IO resources
  * This delay startup check strategy is used to check the state after a {delayInMilliSec} ms delay
  * Uses:
- *      myContainer.withStartupCheckStrategy(new IsRunningStartupCheckStrategyWithDelay(1000));
- *      myContainer.withStartupCheckStrategy(new IsRunningStartupCheckStrategyWithDelay()); // uses 5000ms as default delay
+ *      myContainer.withStartupCheckStrategy(new IsRunningStartupCheckStrategyWithDelay(5000));
+ *      myContainer.withStartupCheckStrategy(new IsRunningStartupCheckStrategyWithDelay()); // uses 1000ms as default delay
  */
 
 
@@ -28,7 +28,7 @@ public class IsRunningStartupCheckStrategyWithDelay extends IsRunningStartupChec
     }
 
     public IsRunningStartupCheckStrategyWithDelay() {
-        this.delayInMilliSec = 5000;
+        this.delayInMilliSec = 1000;
     }
 
 

--- a/junit-testcontainer-commons/src/main/java/io/appform/testcontainers/commons/IsRunningStartupCheckStrategyWithDelay.java
+++ b/junit-testcontainer-commons/src/main/java/io/appform/testcontainers/commons/IsRunningStartupCheckStrategyWithDelay.java
@@ -11,9 +11,10 @@ import java.util.concurrent.TimeUnit;
 
 /*
  * Sometimes the test container startup checks fails due to container not up or busy in acquiring IO resources
- * This delay statup check strategy is used to check the state after a {delayInMilliSec} ms delay
+ * This delay startup check strategy is used to check the state after a {delayInMilliSec} ms delay
  * Uses:
- *      myContainer.withStartupCheckStrategy(new IsRunningStartupCheckStrategyWithDelay(5000));
+ *      myContainer.withStartupCheckStrategy(new IsRunningStartupCheckStrategyWithDelay(1000));
+ *      myContainer.withStartupCheckStrategy(new IsRunningStartupCheckStrategyWithDelay()); // uses 5000ms as default delay
  */
 
 

--- a/junit-testcontainer-commons/src/main/java/io/appform/testcontainers/commons/IsRunningStartupCheckStrategyWithDelay.java
+++ b/junit-testcontainer-commons/src/main/java/io/appform/testcontainers/commons/IsRunningStartupCheckStrategyWithDelay.java
@@ -37,7 +37,7 @@ public class IsRunningStartupCheckStrategyWithDelay extends IsRunningStartupChec
 
         try {
             // startup with delay.
-            await().pollDelay(5000, TimeUnit.MILLISECONDS).until(() -> true);
+            await().pollDelay(delayInMilliSec, TimeUnit.MILLISECONDS).until(() -> true);
         } catch (Exception e) {
             log.error("Unable to pause thread", e);
         }

--- a/junit-testcontainer-commons/src/main/java/io/appform/testcontainers/commons/IsRunningStartupCheckStrategyWithDelay.java
+++ b/junit-testcontainer-commons/src/main/java/io/appform/testcontainers/commons/IsRunningStartupCheckStrategyWithDelay.java
@@ -1,0 +1,47 @@
+package io.appform.testcontainers.commons;
+
+import static org.awaitility.Awaitility.await;
+
+import com.github.dockerjava.api.DockerClient;
+import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
+import java.util.concurrent.TimeUnit;
+
+
+
+/*
+ * Sometimes the test container startup checks fails due to container not up or busy in acquiring IO resources
+ * This delay statup check strategy is used to check the state after a {delayInMilliSec} ms delay
+ * Uses:
+ *      myContainer.withStartupCheckStrategy(new IsRunningStartupCheckStrategyWithDelay(5000));
+ */
+
+
+@Slf4j
+public class IsRunningStartupCheckStrategyWithDelay extends IsRunningStartupCheckStrategy {
+    
+    private final long delayInMilliSec;
+    
+    public IsRunningStartupCheckStrategyWithDelay(final long delayInMilliSec) {
+        this.delayInMilliSec = delayInMilliSec;
+    }
+
+    public IsRunningStartupCheckStrategyWithDelay() {
+        this.delayInMilliSec = 5000;
+    }
+
+
+    @Override
+    public StartupStatus checkStartupState(DockerClient dockerClient, String containerId) {
+
+        try {
+            // startup with delay.
+            await().pollDelay(5000, TimeUnit.MILLISECONDS).until(() -> true);
+        } catch (Exception e) {
+            log.error("Unable to pause thread", e);
+        }
+        
+        return super.checkStartupState(dockerClient, containerId);
+    }
+
+}

--- a/junit-testcontainer-demo/pom.xml
+++ b/junit-testcontainer-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.14</version>
+        <version>1.0.15</version>
     </parent>
 
     <artifactId>junit-testcontainer-demo</artifactId>

--- a/junit-testcontainer-elasticsearch/pom.xml
+++ b/junit-testcontainer-elasticsearch/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.14</version>
+        <version>1.0.15</version>
     </parent>
 
     <artifactId>junit-testcontainer-elasticsearch</artifactId>

--- a/junit-testcontainer-hbase-1.x/pom.xml
+++ b/junit-testcontainer-hbase-1.x/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.14</version>
+        <version>1.0.15</version>
     </parent>
 
     <artifactId>junit-testcontainer-hbase-1.x</artifactId>

--- a/junit-testcontainer-hbase-2.x/pom.xml
+++ b/junit-testcontainer-hbase-2.x/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.14</version>
+        <version>1.0.15</version>
     </parent>
 
     <artifactId>junit-testcontainer-hbase-2.x</artifactId>

--- a/junit-testcontainer-mariadb/pom.xml
+++ b/junit-testcontainer-mariadb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.14</version>
+        <version>1.0.15</version>
     </parent>
 
     <artifactId>junit-testcontainer-mariadb</artifactId>

--- a/junit-testcontainer-rabbitmq/pom.xml
+++ b/junit-testcontainer-rabbitmq/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.14</version>
+        <version>1.0.15</version>
     </parent>
 
     <artifactId>junit-testcontainer-rabbitmq</artifactId>

--- a/junit-testcontainer-rabbitmq/src/main/java/io/appform/testcontainers/rabbitmq/container/RabbitMQContainer.java
+++ b/junit-testcontainer-rabbitmq/src/main/java/io/appform/testcontainers/rabbitmq/container/RabbitMQContainer.java
@@ -3,6 +3,7 @@ package io.appform.testcontainers.rabbitmq.container;
 import io.appform.testcontainers.commons.ContainerUtils;
 import io.appform.testcontainers.rabbitmq.RabbitMQStatusCheck;
 import io.appform.testcontainers.rabbitmq.config.RabbitMQContainerConfiguration;
+import io.appform.testcontainers.commons.IsRunningStartupCheckStrategyWithDelay;
 import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.GenericContainer;
@@ -27,7 +28,8 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
             .withExposedPorts(rabbitMQContainerConfiguration.getPort(), rabbitMQContainerConfiguration.getManagementPort())
             .withLogConsumer(ContainerUtils.containerLogsConsumer(log))
             .waitingFor(new RabbitMQStatusCheck(rabbitMQContainerConfiguration))
-            .withStartupTimeout(rabbitMQContainerConfiguration.getTimeoutDuration());
+            .withStartupTimeout(rabbitMQContainerConfiguration.getTimeoutDuration())
+            .withStartupCheckStrategy(new IsRunningStartupCheckStrategyWithDelay());
         this.rabbitMQContainerConfiguration = rabbitMQContainerConfiguration;
     }
 

--- a/junit-testcontainer-zookeeper/pom.xml
+++ b/junit-testcontainer-zookeeper/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.testcontainer</groupId>
         <artifactId>junit-testcontainer</artifactId>
-        <version>1.0.14</version>
+        <version>1.0.15</version>
     </parent>
 
     <artifactId>junit-testcontainer-zookeeper</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.testcontainer</groupId>
     <artifactId>junit-testcontainer</artifactId>
-    <version>1.0.14</version>
+    <version>1.0.15</version>
     <packaging>pom</packaging>
     <name>Embedded Testcontainers</name>
     <description>Embedded testcontainers for data stores</description>


### PR DESCRIPTION
Sometimes the test container startup checks fails due to container not up or busy in acquiring IO resources.
This delay startup check strategy is used to check the state after a `{delayInMilliSec}` ms delay.

